### PR TITLE
feat: add DockClicker event filter

### DIFF
--- a/src/nimqml/private/dotherside.nim
+++ b/src/nimqml/private/dotherside.nim
@@ -135,6 +135,7 @@ proc dos_qapplication_quit() {.cdecl, dynlib: dynLibName, importc.}
 proc dos_qapplication_icon(filename: cstring) {.cdecl, dynlib: dynLibName, importc.}
 proc dos_qapplication_delete() {.cdecl, dynlib: dynLibName, importc.}
 proc dos_qapplication_clipboard_setText(content: cstring) {.cdecl, dynlib: dynLibName, importc.}
+proc dos_qapplication_installEventFilter(engine: DosQQmlApplicationEngine) {.cdecl, dynlib: dynLibName, importc.}
 
 # QGuiApplication
 proc dos_qguiapplication_create() {.cdecl, dynlib: dynLibName, importc.}

--- a/src/nimqml/private/qapplication.nim
+++ b/src/nimqml/private/qapplication.nim
@@ -17,6 +17,9 @@ proc icon*(application: QApplication, filename: string) =
 proc setClipboardText*(text: string = "") =
   dos_qapplication_clipboard_setText(text.cstring)
 
+proc installEventFilter*(application: QApplication, engine: QQmlApplicationEngine) =
+  dos_qapplication_installEventFilter(engine.vptr)
+
 proc delete*(application: QApplication) =
   ## Delete the given QApplication
   if application.deleted:


### PR DESCRIPTION
Add an event filter to `qApp` that can detect a dock icon click (in macos) when the main window is hidden or closed.