### PR TITLE
fix(@desktop/general): clicking push notification does expand the app but does not open correct channel/chat

### DIFF
--- a/src/nimqml.nim
+++ b/src/nimqml.nim
@@ -34,6 +34,7 @@ include "nimqml/private/qdeclarative.nim"
 include "nimqml/private/nimqmlmacros.nim"
 include "nimqml/private/singleinstance.nim"
 include "nimqml/private/status/statusevent.nim"
+include "nimqml/private/status/statusosnotification.nim"
 
 
 proc signal_handler*(receiver: pointer, signal: cstring, slot: cstring) =

--- a/src/nimqml/private/dotherside.nim
+++ b/src/nimqml/private/dotherside.nim
@@ -33,6 +33,7 @@ type
   DosQAbstractTableModel = distinct pointer
   DosQAbstractListModel = distinct pointer
   DosStatusEventObject = distinct pointer
+  DosStatusOSNotificationObject = DosQObject
   
   DosParameterDefinition = object
     name: cstring
@@ -345,3 +346,12 @@ proc dos_singleinstance_delete(vptr: DosQObject) {.cdecl, dynlib: dynLibName, im
 proc dos_statusevent_create_showAppEvent(engine: DosQQmlApplicationEngine): DosStatusEventObject {.cdecl, dynlib: dynLibName, importc.}
 proc dos_statusevent_create_osThemeEvent(engine: DosQQmlApplicationEngine): DosStatusEventObject {.cdecl, dynlib: dynLibName, importc.}
 proc dos_statusevent_delete(vptr: DosStatusEventObject) {.cdecl, dynlib: dynLibName, importc.}
+
+# DosStatusOSNotificationObject
+proc dos_statusosnotification_create(): DosStatusOSNotificationObject 
+  {.cdecl, dynlib: dynLibName, importc.}
+proc dos_statusosnotification_show_notification(vptr: DosStatusOSNotificationObject,
+  title: cstring, messsage: cstring, identifier: cstring) 
+  {.cdecl, dynlib: dynLibName, importc.}
+proc dos_statusosnotification_delete(vptr: DosStatusOSNotificationObject) 
+  {.cdecl, dynlib: dynLibName, importc.}

--- a/src/nimqml/private/nimqmltypes.nim
+++ b/src/nimqml/private/nimqmltypes.nim
@@ -135,6 +135,8 @@ type
   StatusEventObject* = ref object of RootObj ## \
     ## A StatusEventObject
     vptr: DosStatusEventObject
+
+  StatusOSNotificationObject* = ref object of QObject 
     
 const
   UserRole* = 0x100

--- a/src/nimqml/private/status/statusevent.nim
+++ b/src/nimqml/private/status/statusevent.nim
@@ -1,10 +1,8 @@
 
-#import ../[nimqmltypes, dotherside]
-
-proc setupDockShowAppEventObject*(self: StatusEventObject, engine: QQmlApplicationEngine) =
+proc setupDockShowAppEventObject(self: StatusEventObject, engine: QQmlApplicationEngine) =
   self.vptr = dos_statusevent_create_showAppEvent(engine.vptr)
 
-proc setupOSThemeEventObject*(self: StatusEventObject, engine: QQmlApplicationEngine) =
+proc setupOSThemeEventObject(self: StatusEventObject, engine: QQmlApplicationEngine) =
   self.vptr = dos_statusevent_create_osThemeEvent(engine.vptr)
 
 proc delete*(self: StatusEventObject) =

--- a/src/nimqml/private/status/statusosnotification.nim
+++ b/src/nimqml/private/status/statusosnotification.nim
@@ -1,0 +1,14 @@
+proc setup(self: StatusOSNotificationObject) =
+  self.vptr = dos_statusosnotification_create()
+
+proc delete*(self: StatusOSNotificationObject) =
+  dos_statusosnotification_delete(self.vptr)
+  self.vptr.resetToNil
+
+proc newStatusOSNotificationObject*(): StatusOSNotificationObject =
+  new(result, delete)
+  result.setup()
+
+proc showNotification*(self: StatusOSNotificationObject, title: string, 
+  message: string, identifier: string) =
+  dos_statusosnotification_show_notification(self.vptr, title, message, identifier)


### PR DESCRIPTION
An interface for using methods of the StatusOSNotification class added
in the `dotherside` project. PR for that part is [here](https://github.com/status-im/dotherside/pull/45).

This is corresponding nimqml part of the issue 2996.

Fixes: #2996