### PR TITLE
perf(qabstractlistmodel): Fix memory leak

### DIFF
--- a/src/nimqml/private/qabstractlistmodel.nim
+++ b/src/nimqml/private/qabstractlistmodel.nim
@@ -31,6 +31,7 @@ proc setup*(self: QAbstractListModel) =
 
   self.vptr = dos_qabstractlistmodel_create(addr(self[]), self.metaObject.vptr,
                                             qobjectCallback, qaimCallbacks).DosQObject
+  self.owner = true
 
 proc delete*(self: QAbstractListModel) =
   ## Delete the given QAbstractItemModel


### PR DESCRIPTION
The qabstractlistmodel never takes ownership of c++ QObject. 
The `owner` variable is defined on nim qobject and is used to mark qml ownership on objects. It needs to be set to true when the qobject is created in nim.

Status desktop crashes with this change because it will try to use the QObject after its destruction.
To be merged after we have a fix on Status desktop.