### PR TITLE
fix: replace `dos_qobject_delete` with `dos_qobject_deleteLater`

### DIFF
--- a/src/nimqml/private/dotherside.nim
+++ b/src/nimqml/private/dotherside.nim
@@ -204,6 +204,7 @@ proc dos_qobject_objectName(qobject: DosQObject): cstring {.cdecl, dynlib: dynLi
 proc dos_qobject_setObjectName(qobject: DosQObject, name: cstring) {.cdecl, dynlib: dynLibName, importc.}
 proc dos_qobject_signal_emit(qobject: DosQObject, signalName: cstring, argumentsCount: cint, arguments: ptr DosQVariantArray) {.cdecl, dynlib: dynLibName, importc.}
 proc dos_qobject_delete(qobject: DosQObject) {.cdecl, dynlib: dynLibName, importc.}
+proc dos_qobject_deleteLater(qobject: DosQObject) {.cdecl, dynlib: dynLibName, importc.}
 proc dos_qobject_signal_connect(sender: DosQObject, signalName: cstring, receiver: DosQObject, slot: cstring, signalType: cint) {.cdecl, dynlib: dynLibName, importc.}
 
 # QAbstractItemModel

--- a/src/nimqml/private/qobject.nim
+++ b/src/nimqml/private/qobject.nim
@@ -61,7 +61,7 @@ proc delete*(self: QObject) =
   ## Delete a QObject
   if not self.owner or self.vptr.isNil:
     return
-  dos_qobject_delete(self.vptr)
+  dos_qobject_deleteLater(self.vptr)
   self.vptr.resetToNil
 
 proc newQObject*(): QObject =


### PR DESCRIPTION
Previously, the code used `dos_qobject_delete`, which could potentially cause problems if the object was still in use, especially if there were pending events for the object in the event queue. This could lead to unexpected crashes.

Also, `dos_qobject_delete` disconnects just before the QObject is deleted, leading to clients not being notified about deletion.

`dos_qobject_deleteLater` ensures that the QObject is not deleted until all its pending events are processed and also ensures that all clients are notified about its deletion.