### PR TITLE
fix(qobject): Crash on signal emit with null vptr

### DIFF
--- a/src/nimqml/private/qobject.nim
+++ b/src/nimqml/private/qobject.nim
@@ -23,6 +23,9 @@ method metaObject*(self: QObject): QMetaObject {.base.} =
   QObject.staticMetaObject
 
 proc emit*(qobject: QObject, signalName: string, arguments: openarray[QVariant] = []) =
+  if qobject.vptr.isNil:
+    return
+
   ## Emit the signal with the given name and values
   var dosArguments: seq[DosQVariant] = @[]
   for argument in arguments:


### PR DESCRIPTION
Fixing crash when using `dos_qobject_deleteLater`
See: https://github.com/status-im/status-desktop/pull/11196#issuecomment-1608080322

When the QObject is deleted with dos_qobject_deleteLater the QObject slots will remain active until the event loop finished processing the events. It can trigger another emit, but this time the vptr will be null.