### PR TITLE
feat: allow passing empty or no roles to `dataChanged`

### DIFF
--- a/src/nimqml/private/qabstractitemmodel.nim
+++ b/src/nimqml/private/qabstractitemmodel.nim
@@ -238,11 +238,15 @@ proc endResetModel*(self: QAbstractItemModel) =
 proc dataChanged*(self: QAbstractItemModel,
                  topLeft: QModelIndex,
                  bottomRight: QModelIndex,
-                 roles: openArray[int]) =
+                 roles: openArray[int] = []) =
   ## Notify the view that the model data changed
   debugMsg("QAbstractItemModel", "dataChanged")
-  var copy: seq[cint]
-  for i in roles:
-    copy.add(i.cint)
-  dos_qabstractitemmodel_dataChanged(self.vptr.DosQAbstractItemModel, topLeft.vptr,
-                                     bottomRight.vptr, copy[0].addr, copy.len.cint)
+  if roles.len == 0:
+    dos_qabstractitemmodel_dataChanged(self.vptr.DosQAbstractItemModel, topLeft.vptr,
+                                       bottomRight.vptr, nil, 0)
+  else:
+    var copy: seq[cint]
+    for i in roles:
+      copy.add(i.cint)
+    dos_qabstractitemmodel_dataChanged(self.vptr.DosQAbstractItemModel, topLeft.vptr,
+                                       bottomRight.vptr, copy[0].addr, copy.len.cint)


### PR DESCRIPTION
which follows the C++ semantics meaning _all_ roles (cf https://doc.qt.io/qt-5/qabstractitemmodel.html#dataChanged)

Related: https://github.com/status-im/status-desktop/issues/11830