### PR TITLE
feat: Add restartApp support

### DIFF
--- a/src/nimqml/private/dotherside.nim
+++ b/src/nimqml/private/dotherside.nim
@@ -137,6 +137,7 @@ proc dos_qguiapplication_try_enable_threaded_renderer() {.cdecl, dynlib: dynLibN
 proc dos_qguiapplication_create() {.cdecl, dynlib: dynLibName, importc.}
 proc dos_qguiapplication_exec() {.cdecl, dynlib: dynLibName, importc.}
 proc dos_qguiapplication_quit() {.cdecl, dynlib: dynLibName, importc.}
+proc dos_qguiapplication_restart() {.cdecl, dynlib: dynLibName, importc.}
 proc dos_qguiapplication_icon(filename: cstring) {.cdecl, dynlib: dynLibName, importc.}
 proc dos_qguiapplication_delete() {.cdecl, dynlib: dynLibName, importc.}
 

--- a/src/nimqml/private/qguiapplication.nim
+++ b/src/nimqml/private/qguiapplication.nim
@@ -32,6 +32,10 @@ proc quit*(self: QGuiApplication) =
   ## Quit the Qt event loop
   dos_qguiapplication_quit()
 
+proc restartApplication*() =
+  ## Restart the app
+  dos_qguiapplication_restart()
+
 proc setClipboardText*(text: string = "") =
   dos_qguiapplication_clipboard_setText(text.cstring)
 


### PR DESCRIPTION
Related PR: https://github.com/status-im/status-desktop/pull/13284

Adding the API used to restart the application.
The API implementation is in DOtherSide.