### PR TITLE
chore: Expose openUrl API

### DIFF
--- a/src/nimqml.nim
+++ b/src/nimqml.nim
@@ -37,6 +37,7 @@ include "nimqml/private/status/statusevent.nim"
 include "nimqml/private/status/statusosnotification.nim"
 include "nimqml/private/status/statuskeychainmanager.nim"
 include "nimqml/private/status/statussoundmanager.nim"
+include "nimqml/private/qdesktopservices.nim"
 
 proc signal_handler*(receiver: pointer, signal: cstring, slot: cstring) =
   var dosqobj = cast[DosQObject](receiver)

--- a/src/nimqml/private/dotherside.nim
+++ b/src/nimqml/private/dotherside.nim
@@ -434,3 +434,6 @@ proc dos_app_make_it_active(engine: DosQQmlApplicationEngine) {.cdecl, dynlib: d
 
 # Common
 proc dos_installMessageHandler(handler: DosMessageHandler) {.cdecl, dynlib: dynLibName, importc.}
+
+# QDesktopServices
+proc dos_qdesktopservices_open_url(url: cstring): bool {.cdecl, dynlib: dynLibName, importc.}

--- a/src/nimqml/private/qdesktopservices.nim
+++ b/src/nimqml/private/qdesktopservices.nim
@@ -1,0 +1,3 @@
+proc openUrl*(url: string = ""): bool =
+  ## Open the given URL in the appropriate browser
+  return dos_qdesktopservices_open_url(url.cstring)


### PR DESCRIPTION
Exposing openUrl API. This is meant to replace the nim `browsers` module dependency.