### PR TITLE
fix: Allow pragmas with params on QtObjects

### DIFF
--- a/src/nimqml/private/nimqmlmacros.nim
+++ b/src/nimqml/private/nimqmlmacros.nim
@@ -142,8 +142,8 @@ proc getPragmas(n: NimNode): seq[string] {.compiletime.} =
     return
   let pragma = pragmas[0]
   for c in pragma:
-    doAssert(c.kind == nnkIdent)
-    result.add($c)
+    if c.kind == nnkIdent:
+      result.add($c)
 
 
 proc extractQObjectTypeDef(head: NimNode): FindQObjectTypeResult {.compiletime.} =


### PR DESCRIPTION
Fixing an issue where using custom pragmas with params would fail to compile due to nimqml

E.g.
```
proc testSlot() string {.slot, customPragma("someParam").} = "someValue"
```