### PR TITLE
chore: remove OSThemeEvent handling

### DIFF
--- a/src/nimqml/private/dotherside.nim
+++ b/src/nimqml/private/dotherside.nim
@@ -364,7 +364,6 @@ proc dos_singleinstance_isfirst(vptr: DosQObject): bool {.cdecl, dynlib: dynLibN
 proc dos_singleinstance_delete(vptr: DosQObject) {.cdecl, dynlib: dynLibName, importc.}
 
 # DosStatusEvent
-proc dos_event_create_osThemeEvent(engine: DosQQmlApplicationEngine): DosStatusEvent {.cdecl, dynlib: dynLibName, importc.}
 proc dos_event_create_urlSchemeEvent(): DosStatusEvent {.cdecl, dynlib: dynLibName, importc.}
 proc dos_event_delete(vptr: DosStatusEvent) {.cdecl, dynlib: dynLibName, importc.}
 

--- a/src/nimqml/private/status/statusevent.nim
+++ b/src/nimqml/private/status/statusevent.nim
@@ -1,16 +1,9 @@
-proc setupOSThemeEventObject*(self: StatusEvent, engine: QQmlApplicationEngine) =
-  self.vptr = dos_event_create_osThemeEvent(engine.vptr)
-
 proc setupUrlSchemeEventObject(self: StatusEvent) =
   self.vptr = dos_event_create_urlSchemeEvent()
 
 proc delete*(self: StatusEvent) =
   dos_event_delete(self.vptr)
   self.vptr.resetToNil
-
-proc newStatusOSThemeEventObject*(engine: QQmlApplicationEngine): StatusEvent =
-  new(result, delete)
-  result.setupOSThemeEventObject(engine)
 
 proc newStatusUrlSchemeEventObject*(): StatusEvent =
   new(result, delete)


### PR DESCRIPTION
- can be handled fully by QML under Qt6 

Iterates status-im/status-desktop#17637
Needed by status-im/status-desktop#17764